### PR TITLE
[WIP] Use Guzzle instead of Buzz

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,38 @@ As you can see by these examples, you always have to to go through the API Root
 to make an action. This is because the API is discoverable and that the SDK
 should not know anything beside the API's entry point.
 
+### HTTP client customization
+
+SensiolabsConnect relies on Guzzle HTTP client. It comes configured with an HTTP cache adapter and the backoff plugin.
+However, you can disable these plugins and and yours:
+
+Disabling/Enabling plugins:
+
+```php
+use SensioLabs\Connect\OAuthConsumer;
+
+$app['connect_consumer'] = new OAuthConsumer($id, $secret, $scope, array(
+   'cache_options' => false,                                   // disables the cache plugin
+   'backoff_options' => false,                                 // disables the backoff plugin
+   'plugins' => array(new Guzzle\Plugin\History\HistoryPlugin) // adds an array of plugins
+));
+```
+
+You can also configure the cache and backoff plugins:
+
+```php
+use SensioLabs\Connect\OAuthConsumer;
+
+$app['connect_consumer'] = new OAuthConsumer($id, $secret, $scope, array(
+   'cache_options' => new DoctrineCacheAdapter(new FilesystemCache('/path/to/cache/files')), 
+   'backoff_options' => array('max_retries' => 5),
+));
+```
+
+Notes:
+ - `cache_options` accepts any of the Guzzle Cache options, see https://github.com/guzzle/plugin-cache/blob/master/CachePlugin.php#L41-L50
+ - `backoff_options` has three parameters: `max_retries`, `http_codes` and `curl_codes`.
+
 ## License
 
 This library is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -24,93 +24,101 @@ possession of your `application_id`, `application_secret` and `scope`.
 
 1. Configure your silex app with the data we gave us at app registration.
 
-        // index.php
-        use SensioLabs\Connect\Api\Api;
-        use SensioLabs\Connect\OAuthConsumer;
+```php
+// index.php
+use SensioLabs\Connect\Api\Api;
+use SensioLabs\Connect\OAuthConsumer;
 
-        $app = new Silex\Application();
-        $app['connect_id'] = 'application_id';
-        $app->register(new Silex\Provider\UrlGeneratorServiceProvider());
-        $app->register(new Silex\Provider\SessionServiceProvider());
+$app = new Silex\Application();
+$app['connect_id'] = 'application_id';
+$app->register(new Silex\Provider\UrlGeneratorServiceProvider());
+$app->register(new Silex\Provider\SessionServiceProvider());
 
-        $app['connect_secret'] = 'application_secret';
-        // List of scope copy-pasted from your application page on SensioLabs Connect
-        $app['connect_scope'] = array(
-            'SCOPE_ADDITIONAL_EMAILS',
-            'SCOPE_BIRTHDAY',
-            'SCOPE_EMAIL',
-            'SCOPE_LOCATION',
-            'SCOPE_PRIVATE_MEMBERSHIPS',
-            'SCOPE_PRIVATE_PROJECTS',
-            'SCOPE_PUBLIC',
-            'SCOPE_SSH_KEYS',
-        );
+$app['connect_secret'] = 'application_secret';
+// List of scope copy-pasted from your application page on SensioLabs Connect
+$app['connect_scope'] = array(
+    'SCOPE_ADDITIONAL_EMAILS',
+    'SCOPE_BIRTHDAY',
+    'SCOPE_EMAIL',
+    'SCOPE_LOCATION',
+    'SCOPE_PRIVATE_MEMBERSHIPS',
+    'SCOPE_PRIVATE_PROJECTS',
+    'SCOPE_PUBLIC',
+    'SCOPE_SSH_KEYS',
+);
 
-        $app['connect_consumer'] = new OAuthConsumer(
-            $app['connect_id'],
-            $app['connect_secret'],
-            implode(' ', $app['connect_scope']) // scope MUST be space separated
-        );
-        $app['connect_api'] = new Api();
+$app['connect_consumer'] = new OAuthConsumer(
+    $app['connect_id'],
+    $app['connect_secret'],
+    implode(' ', $app['connect_scope']) // scope MUST be space separated
+);
+$app['connect_api'] = new Api();
+```
 
-    This done. We can now move on to the second step.
+This done. We can now move on to the second step.
 
 2. We need to create two controllers to handle the OAuth2 Three-Legged worflow.
 
-   The first controller goal is to redirect the user to SensioLabs Connect in
-   order to ask him for the authorization that your app will use his data. This
-   controller will be bound to the `connect_auth` route. In your template,
-   you'll need to create a link to this route.
+The first controller goal is to redirect the user to SensioLabs Connect in
+order to ask him for the authorization that your app will use his data. This
+controller will be bound to the `connect_auth` route. In your template,
+you'll need to create a link to this route.
 
-        // index.php
-        $app->get('/connect/new', function () use ($app) {
-            $callback = $app['url_generator']->generate('connect_callback', array(), true);
-            $url = $app['connect_consumer']->getAuthorizationUri($callback);
+```php
+// index.php
+$app->get('/connect/new', function () use ($app) {
+    $callback = $app['url_generator']->generate('connect_callback', array(), true);
+    $url = $app['connect_consumer']->getAuthorizationUri($callback);
+    
+    return $app->redirect($url);
+})->bind('connect_auth');
+```
 
-            return $app->redirect($url);
-        })->bind('connect_auth');
+The second controller is the one that will welcome the user after SensioLabs
+Connect redirected him to your application. When registering your client,
+you'll have to provide the exact absolute URL that points to this
+controller.
 
-    The second controller is the one that will welcome the user after SensioLabs
-    Connect redirected him to your application. When registering your client,
-    you'll have to provide the exact absolute URL that points to this
-    controller.
+```php
+$app->get('/connect/callback', function (Request $request) use ($app) {
+    // There was an error during the workflow.
+    if ($request->get('error')) {
+        throw new \RuntimeException($request->get('error_description'));
+    }
 
-        $app->get('/connect/callback', function (Request $request) use ($app) {
-            // There was an error during the workflow.
-            if ($request->get('error')) {
-                throw new \RuntimeException($request->get('error_description'));
-            }
+    // Everything went fine, you can now request an access token.
+    try {
+        $data = $app['connect_consumer']->requestAccessToken($app['url_generator']->generate('connect_callback', array(), true), $request->get('code'));
+    } catch (OAuthException $e) {
+        throw $e;
+    }
 
-            // Everything went fine, you can now request an access token.
-            try {
-                $data = $app['connect_consumer']->requestAccessToken($app['url_generator']->generate('connect_callback', array(), true), $request->get('code'));
-            } catch (OAuthException $e) {
-                throw $e;
-            }
+    // At this point, we have an access token and we can use the SDK to request the API
+    $app['connect_api']->setAccessToken($data['access_token']); // All further request will be done with this access token
+    $root = $app['connect_api']->getRoot();
+    $user = $root->getCurrentUser();
+    $user->getBadges()->refresh();
 
-            // At this point, we have an access token and we can use the SDK to request the API
-            $app['connect_api']->setAccessToken($data['access_token']); // All further request will be done with this access token
-            $root = $app['connect_api']->getRoot();
-            $user = $root->getCurrentUser();
-            $user->getBadges()->refresh();
+    $app['session']->start();
+    $app['session']->set('connect_access_token', $data['access_token']);
+    $app['session']->set('connect_user', $user);
 
-            $app['session']->start();
-            $app['session']->set('connect_access_token', $data['access_token']);
-            $app['session']->set('connect_user', $user);
-
-            return $app->redirect('/');
-        })->bind('connect_callback');
+    return $app->redirect('/');
+})->bind('connect_callback');
+```
 
 3. Create a link from your template
 
-   In a template, you can use the following snippet of code to render a
-   SensioLabsConnect button:
+In a template, you can use the following snippet of code to render a
+SensioLabsConnect button:
 
-        <a href="#" class="connect-with-sensiolabs">
-            <span>Connect With Sensiolabs</span>
-        </a>
+```html
+<a href="#" class="connect-with-sensiolabs">
+    <span>Connect With Sensiolabs</span>
+</a>
+```
 
-   And include the following CSS file: `https://connect.sensiolabs.com/css/sln.css`
+And include the following CSS file: `https://connect.sensiolabs.com/css/sln.css`
 
 Et voilà! Your application can now use SensioLabs Connect as an authentication
 method!
@@ -124,42 +132,48 @@ Here are some useful recipies.
 
 1. Search
 
-        $root = $api->getRoot();
-        
-        // Will search for project with 'symfony' query
-        $projects = $root->getProjects('symfony');
+```php
+$root = $api->getRoot();
 
-        // Same for users
-        $users = $root->getUsers('fab');
+// Will search for project with 'symfony' query
+$projects = $root->getProjects('symfony');
 
-        // Same for clubs
-        $clubs = $root->getClubs('sensio');
+// Same for users
+$users = $root->getUsers('fab');
+
+// Same for clubs
+$clubs = $root->getClubs('sensio');
+```
 
 2. Create a new club
 
-        // Create Club
-        $club = new \SensioLabs\Connect\Api\Entity\Club();
-        $club->setName("SensioLabs France");
-        $club->setSlug("sensiolabs-api-users");
-        $club->setType(\SensioLabs\Connect\Api\Entity\Club::TYPE_USER_GROUP);
-        $club->setEmail('foobar@example.com');
-        $club->setDescription('This is the best description i found.');
-        $club->setCity("Paris");
-        $club->setCountry("France");
-        $club->setUrl('http://sensiolabs.com');
-        
-        // Save new Club
-        $app['connect_api']->setAccessToken($app['session']->get('connect_access_token'));
-        $root = $app['connect_api']->getRoot();
-        $response = $root->getClubs()->submitForm($club);
+```php
+// Create Club
+$club = new \SensioLabs\Connect\Api\Entity\Club();
+$club->setName("SensioLabs France");
+$club->setSlug("sensiolabs-api-users");
+$club->setType(\SensioLabs\Connect\Api\Entity\Club::TYPE_USER_GROUP);
+$club->setEmail('foobar@example.com');
+$club->setDescription('This is the best description i found.');
+$club->setCity("Paris");
+$club->setCountry("France");
+$club->setUrl('http://sensiolabs.com');
+
+// Save new Club
+$app['connect_api']->setAccessToken($app['session']->get('connect_access_token'));
+$root = $app['connect_api']->getRoot();
+$response = $root->getClubs()->submitForm($club);
+```
 
 3. Edit authenticated user
 
-        $app['connect_api']->setAccessToken($app['session']->get('connect_access_token'));
-        $root = $app['connect_api']->getRoot();
-        $user = $root->getCurrentUser();
-        $user->setBiography("I'm sexy and I know it.");
-        $user->submitForm();
+```php
+$app['connect_api']->setAccessToken($app['session']->get('connect_access_token'));
+$root = $app['connect_api']->getRoot();
+$user = $root->getCurrentUser();
+$user->setBiography("I'm sexy and I know it.");
+$user->submitForm();
+```
 
 As you can see by these examples, you always have to to go through the API Root
 to make an action. This is because the API is discoverable and that the SDK

--- a/README.md
+++ b/README.md
@@ -184,24 +184,29 @@ should not know anything beside the API's entry point.
 SensiolabsConnect relies on Guzzle HTTP client. It comes configured with an HTTP cache adapter and the backoff plugin.
 However, you can disable these plugins and and yours:
 
-Disabling/Enabling plugins:
+All the example above use `SensioLabs\Connect\OAuthConsumer`. However, these options are also available using the
+`SensioLabs\Connect\Api\Api`.
+
+1. Disabling/Enabling plugins:
 
 ```php
 use SensioLabs\Connect\OAuthConsumer;
 
-$app['connect_consumer'] = new OAuthConsumer($id, $secret, $scope, array(
+$consumer = new OAuthConsumer($id, $secret, $scope, array(
    'cache_options' => false,                                   // disables the cache plugin
    'backoff_options' => false,                                 // disables the backoff plugin
    'plugins' => array(new Guzzle\Plugin\History\HistoryPlugin) // adds an array of plugins
 ));
 ```
 
+2. Configure embedded plugins:
+
 You can also configure the cache and backoff plugins:
 
 ```php
 use SensioLabs\Connect\OAuthConsumer;
 
-$app['connect_consumer'] = new OAuthConsumer($id, $secret, $scope, array(
+$consumer = new OAuthConsumer($id, $secret, $scope, array(
    'cache_options' => new DoctrineCacheAdapter(new FilesystemCache('/path/to/cache/files')), 
    'backoff_options' => array('max_retries' => 5),
 ));
@@ -210,6 +215,20 @@ $app['connect_consumer'] = new OAuthConsumer($id, $secret, $scope, array(
 Notes:
  - `cache_options` accepts any of the Guzzle Cache options, see https://github.com/guzzle/plugin-cache/blob/master/CachePlugin.php#L41-L50
  - `backoff_options` has three parameters: `max_retries`, `http_codes` and `curl_codes`.
+
+3. Customize HTTP connection
+
+There are three options to customize the HTTP connection: `timeout`, `connect_timeout` and `proxy`:
+
+```php
+use SensioLabs\Connect\OAuthConsumer;
+
+$consumer = new OAuthConsumer($id, $secret, $scope, array(
+   'timeout' => 4,                                        // maximum number of seconds to allow for an entire transfer to take place before timing out
+   'connect_timeout' => 3,                                // maximum number of seconds to wait while trying to connect
+   'proxy' => 'http://username:password@192.168.16.1:10', // specify an HTTP proxy
+));
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ To install the SDK, run the command below and you will get the latest version:
 
     composer require sensiolabs/connect
 
+## Upgrade
+
+### Version 4:
+
+BC Break: As of version 4, Connect does not use [Buzz](https://github.com/kriswallsmith/Buzz) as HTTP client anymore. 
+It now uses [Guzzle 3](https://github.com/guzzle/guzzle3) that is  compatible with Guzzle 4, but PHP 5.3 compatible.
+
 ## Usage
 
 ### OAuth

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,13 @@
         }
     ],
     "require": {
-        "kriswallsmith/buzz": "~0.8",
+        "guzzle/http": "~3.0",
         "psr/log": "~1.0"
     },
     "require-dev": {
         "symfony/form": "~2.1",
-        "symfony/security": "~2.3"
+        "symfony/security": "~2.3",
+        "guzzle/plugin-mock": "~3.0"
     },
     "suggest": {
         "symfony/security": "To use in a Symfony environment"

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "symfony/form": "~2.1",
+        "symfony/security": "~2.3",
         "guzzle/plugin-mock": "~3.0",
         "doctrine/cache": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     ],
     "require": {
         "guzzle/http": "~3.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "guzzle/plugin-cache": "~3.0",
+        "guzzle/plugin-backoff": "~3.0"
     },
     "require-dev": {
         "symfony/form": "~2.1",
@@ -27,7 +29,8 @@
     "autoload": {
         "psr-0": {
             "SensioLabs": ["src/"]
-        }
+        },
+        "files": ["src/SensioLabs/Connect/functions.php"]
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,12 @@
     },
     "require-dev": {
         "symfony/form": "~2.1",
-        "symfony/security": "~2.3",
-        "guzzle/plugin-mock": "~3.0"
+        "guzzle/plugin-mock": "~3.0",
+        "doctrine/cache": "~1.0"
     },
     "suggest": {
-        "symfony/security": "To use in a Symfony environment"
+        "symfony/security": "To use in a Symfony environment",
+        "doctrine/cache": "To get the benefit of HTTP cache"
     },
     "autoload": {
         "psr-0": {

--- a/src/SensioLabs/Connect/Api/Api.php
+++ b/src/SensioLabs/Connect/Api/Api.php
@@ -37,9 +37,22 @@ class Api
     private $endpoint;
     private $accessToken;
 
-    public function __construct($endpoint = null, Guzzle $client = null, ParserInterface $parser = null, LoggerInterface $logger = null)
+    /**
+     * @param string            $endpoint The API enpoint
+     * @param null|array|Guzzle $client   Either a Guzzle client or an array of options
+     * @param ParserInterface   $parser   A parser
+     * @param LoggerInterface   $logger   A logger
+     */
+    public function __construct($endpoint = null, $client = null, ParserInterface $parser = null, LoggerInterface $logger = null)
     {
-        $this->client = $client ?: new Guzzle(self::ENDPOINT);
+        if ($client instanceof Guzzle) {
+            $this->client = $client;
+        } elseif (is_array($client)) {
+            $this->client = \SensioLabs\Connect\createClient(self::ENDPOINT, $client);
+        } else {
+            $this->client = \SensioLabs\Connect\createClient(self::ENDPOINT, array());
+        }
+
         $this->parser = $parser ?: new Parser();
         $this->endpoint = $endpoint ?: self::ENDPOINT;
         $this->logger = $logger ?: new NullLogger();

--- a/src/SensioLabs/Connect/Api/Api.php
+++ b/src/SensioLabs/Connect/Api/Api.php
@@ -31,15 +31,15 @@ class Api
 {
     const ENDPOINT = 'https://connect.sensiolabs.com/api';
 
-    private $browser;
+    private $client;
     private $parser;
     private $logger;
     private $endpoint;
     private $accessToken;
 
-    public function __construct($endpoint = null, Guzzle $browser = null, ParserInterface $parser = null, LoggerInterface $logger = null)
+    public function __construct($endpoint = null, Guzzle $client = null, ParserInterface $parser = null, LoggerInterface $logger = null)
     {
-        $this->browser = $browser ?: new Guzzle(self::ENDPOINT);
+        $this->client = $client ?: new Guzzle(self::ENDPOINT);
         $this->parser = $parser ?: new Parser();
         $this->endpoint = $endpoint ?: self::ENDPOINT;
         $this->logger = $logger ?: new NullLogger();
@@ -73,7 +73,7 @@ class Api
 
         $this->logger->info(sprintf('GET %s', $url));
 
-        return $this->processResponse($this->browser->get($url, array_merge($headers, $this->getAcceptHeader()), array('exceptions' => false))->send());
+        return $this->processResponse($this->client->get($url, array_merge($headers, $this->getAcceptHeader()), array('exceptions' => false))->send());
     }
 
     public function post($url, array $fields, $headers = array())
@@ -84,7 +84,7 @@ class Api
         $this->logger->debug(sprintf('Posted headers: %s', json_encode($headers)));
         $this->logger->debug(sprintf('Posted fields: %s', json_encode($fields)));
 
-        $request = $this->browser->post($url, array_merge($headers, $this->getAcceptHeader()), null, array('exceptions' => false));
+        $request = $this->client->post($url, array_merge($headers, $this->getAcceptHeader()), null, array('exceptions' => false));
         $request->addPostFields($fields);
 
         return $this->processResponse($request->send());

--- a/src/SensioLabs/Connect/Api/Api.php
+++ b/src/SensioLabs/Connect/Api/Api.php
@@ -86,7 +86,7 @@ class Api
 
         $this->logger->info(sprintf('GET %s', $url));
 
-        return $this->processResponse($this->client->get($url, array_merge($headers, $this->getAcceptHeader()), array('exceptions' => false))->send());
+        return $this->processResponse($this->client->get($url, array_merge($headers, $this->getAcceptHeader()))->send());
     }
 
     public function post($url, array $fields, $headers = array())
@@ -97,7 +97,7 @@ class Api
         $this->logger->debug(sprintf('Posted headers: %s', json_encode($headers)));
         $this->logger->debug(sprintf('Posted fields: %s', json_encode($fields)));
 
-        $request = $this->client->post($url, array_merge($headers, $this->getAcceptHeader()), null, array('exceptions' => false));
+        $request = $this->client->post($url, array_merge($headers, $this->getAcceptHeader()), null);
         $request->addPostFields($fields);
 
         return $this->processResponse($request->send());

--- a/src/SensioLabs/Connect/Api/Api.php
+++ b/src/SensioLabs/Connect/Api/Api.php
@@ -53,6 +53,9 @@ class Api
             $this->client = \SensioLabs\Connect\createClient(self::ENDPOINT, array());
         }
 
+        // mandatory here, we don't want exceptions
+        $this->client->setDefaultOption('exceptions', false);
+
         $this->parser = $parser ?: new Parser();
         $this->endpoint = $endpoint ?: self::ENDPOINT;
         $this->logger = $logger ?: new NullLogger();
@@ -109,12 +112,12 @@ class Api
     public function submit($url, $method = 'POST', array $fields, $headers = array())
     {
         switch (strtolower($method)) {
-            case 'GET':
+            case 'get':
                 return $this->get($url, $headers);
-            case 'POST':
+            case 'post':
                 return $this->post($url, $fields, $headers);
             default:
-                throw new \InvalidArgumentException(sprintf('Method %s is not supported.'));
+                throw new \InvalidArgumentException(sprintf('Method %s is not supported.', $method));
         }
     }
 

--- a/src/SensioLabs/Connect/OAuthConsumer.php
+++ b/src/SensioLabs/Connect/OAuthConsumer.php
@@ -39,9 +39,24 @@ class OAuthConsumer
         'authorize'      => '/oauth/authorize',
     );
 
-    public function __construct($appId, $appSecret, $scope, $endpoint = null, Guzzle $client = null, LoggerInterface $logger = null)
+    /**
+     * @param string            $appId     The application Id
+     * @param string            $appSecret The application secret
+     * @param string            $scope     The application scope
+     * @param string            $endpoint  The oauth endpoint
+     * @param null|array|Guzzle $client    Either a Guzzle client or an array of options
+     * @param LoggerInterface   $logger    A logger
+     */
+    public function __construct($appId, $appSecret, $scope, $endpoint = null, $client = null, LoggerInterface $logger = null)
     {
-        $this->client    = $client ?: new Guzzle(self::ENDPOINT);
+        if ($client instanceof Guzzle) {
+            $this->client = $client;
+        } elseif (is_array($client)) {
+            $this->client = \SensioLabs\Connect\createClient(self::ENDPOINT, $client);
+        } else {
+            $this->client = \SensioLabs\Connect\createClient(self::ENDPOINT, array());
+        }
+
         $this->appId     = $appId;
         $this->appSecret = $appSecret;
         $this->scope     = $scope;

--- a/src/SensioLabs/Connect/OAuthConsumer.php
+++ b/src/SensioLabs/Connect/OAuthConsumer.php
@@ -27,7 +27,7 @@ class OAuthConsumer
 {
     const ENDPOINT = 'https://connect.sensiolabs.com';
 
-    private $browser;
+    private $client;
     private $appId;
     private $appSecret;
     private $scope;
@@ -39,9 +39,9 @@ class OAuthConsumer
         'authorize'      => '/oauth/authorize',
     );
 
-    public function __construct($appId, $appSecret, $scope, $endpoint = null, Guzzle $browser = null, LoggerInterface $logger = null)
+    public function __construct($appId, $appSecret, $scope, $endpoint = null, Guzzle $client = null, LoggerInterface $logger = null)
     {
-        $this->browser   = $browser ?: new Guzzle(self::ENDPOINT);
+        $this->client    = $client ?: new Guzzle(self::ENDPOINT);
         $this->appId     = $appId;
         $this->appSecret = $appSecret;
         $this->scope     = $scope;
@@ -97,7 +97,7 @@ class OAuthConsumer
         $this->logger->info(sprintf("Requesting AccessToken to '%s'", $url));
         $this->logger->debug(sprintf("Sent params: %s", json_encode($params)));
 
-        $request = $this->browser->post($url, $params, array('exceptions' => false));
+        $request = $this->client->post($url, $params, array('exceptions' => false));
         $request->addPostFields($params);
         $response = $request->send();
 
@@ -146,9 +146,19 @@ class OAuthConsumer
         return $this->endpoint;
     }
 
+    /**
+     * @deprecated Deprecated since 4.0, use getClient instead
+     *
+     * @return Guzzle
+     */
     public function getBrowser()
     {
-        return $this->browser;
+        return $this->getClient();
+    }
+
+    public function getClient()
+    {
+        return $this->client;
     }
 
     public function getLogger()

--- a/src/SensioLabs/Connect/OAuthConsumer.php
+++ b/src/SensioLabs/Connect/OAuthConsumer.php
@@ -112,7 +112,7 @@ class OAuthConsumer
         $this->logger->info(sprintf("Requesting AccessToken to '%s'", $url));
         $this->logger->debug(sprintf("Sent params: %s", json_encode($params)));
 
-        $request = $this->client->post($url, $params, array('exceptions' => false));
+        $request = $this->client->post($url, $params);
         $request->addPostFields($params);
         $response = $request->send();
 

--- a/src/SensioLabs/Connect/Profiler/ConnectDataCollector.php
+++ b/src/SensioLabs/Connect/Profiler/ConnectDataCollector.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the SensioLabs Connect package.
+ *
+ * (c) SensioLabs <contact@sensiolabs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\Connect\Profiler;
+
+use Guzzle\Plugin\History\HistoryPlugin;
+use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Message\Response as GuzzleResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Guzzle\Http\Message\EntityEnclosingRequestInterface;
+
+class ConnectDataCollector extends DataCollector
+{
+    private $profiler;
+
+    public function __construct(HistoryPlugin $profiler)
+    {
+        $this->profiler = $profiler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $this->data = array(
+            'calls'       => array(),
+            'error_count' => 0,
+            'methods'     => array(),
+            'total_time'  => 0,
+        );
+
+        foreach ($this->profiler as $call) {
+            $error = false;
+            $request = $call;
+            $response = $request->getResponse();
+
+            $requestContent = null;
+            if ($request instanceof EntityEnclosingRequestInterface) {
+                $requestContent = (string) $request->getBody();
+            }
+            $responseContent = $this->prettifyResponse($response->getBody(true));
+
+            $time = array(
+                'total' => $response->getInfo('total_time'),
+                'connection' => $response->getInfo('connect_time')
+            );
+
+            $this->data['total_time'] += $response->getInfo('total_time');
+
+            if (!isset($this->data['methods'][$request->getMethod()])) {
+                $this->data['methods'][$request->getMethod()] = 0;
+            }
+
+            $this->data['methods'][$request->getMethod()]++;
+
+            if ($response->isError()) {
+                $this->data['error_count']++;
+                $error = true;
+            }
+
+            $this->data['calls'][] = array(
+                'request' => $this->sanitizeRequest($request),
+                'requestContent' => $requestContent,
+                'response' => $this->sanitizeResponse($response),
+                'responseContent' => $responseContent,
+                'time' => $time,
+                'error' => $error
+            );
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getCalls()
+    {
+        return isset($this->data['calls']) ? $this->data['calls'] : array();
+    }
+
+    /**
+     * @return int
+     */
+    public function countErrors()
+    {
+        return isset($this->data['error_count']) ? $this->data['error_count'] : 0;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMethods()
+    {
+        return isset($this->data['methods']) ? $this->data['methods'] : array();
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalTime()
+    {
+        return isset($this->data['total_time']) ? $this->data['total_time'] : 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'connect-sdk';
+    }
+
+    /**
+     * @param RequestInterface $request
+     *
+     * @return array
+     */
+    private function sanitizeRequest(RequestInterface $request)
+    {
+        $postParameters = $request instanceof EntityEnclosingRequestInterface ? $request->getPostFields() : null;
+
+        return array(
+            'method'           => $request->getMethod(),
+            'protocol_version' => $request->getProtocolVersion(),
+            'path'             => $request->getPath(),
+            'scheme'           => $request->getScheme(),
+            'host'             => $request->getHost(),
+            'query'            => $request->getQuery(),
+            'headers'          => $request->getHeaders()->toArray(),
+            'query_parameters' => $request->getUrl(true)->getQuery(),
+            'post_parameters'  => $postParameters,
+        );
+    }
+
+    /**
+     * @param GuzzleResponse $response
+     *
+     * @return array
+     */
+    private function sanitizeResponse($response)
+    {
+        return array(
+            'statusCode'   => $response->getStatusCode(),
+            'reasonPhrase' => $response->getReasonPhrase(),
+            'headers'      => $response->getHeaders()->toArray(),
+        );
+    }
+
+    private function prettifyResponse($body)
+    {
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+
+        if (!@$dom->loadXML($body)) {
+            return $body;
+        }
+
+        return $dom->saveXML();
+    }
+}

--- a/src/SensioLabs/Connect/Profiler/ConnectDataCollector.php
+++ b/src/SensioLabs/Connect/Profiler/ConnectDataCollector.php
@@ -53,7 +53,7 @@ class ConnectDataCollector extends DataCollector
 
             $time = array(
                 'total' => $response->getInfo('total_time'),
-                'connection' => $response->getInfo('connect_time')
+                'connection' => $response->getInfo('connect_time'),
             );
 
             $this->data['total_time'] += $response->getInfo('total_time');
@@ -75,7 +75,7 @@ class ConnectDataCollector extends DataCollector
                 'response' => $this->sanitizeResponse($response),
                 'responseContent' => $responseContent,
                 'time' => $time,
-                'error' => $error
+                'error' => $error,
             );
         }
     }

--- a/src/SensioLabs/Connect/Profiler/Resources/views/Collector/connect-sdk.html.twig
+++ b/src/SensioLabs/Connect/Profiler/Resources/views/Collector/connect-sdk.html.twig
@@ -1,0 +1,471 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% if collector.calls is empty %}
+        {% set color = 'grey' %}
+    {% elseif collector.countErrors > 0 %}
+        {% set color = 'red' %}
+    {% else %}
+        {% set color = 'green' %}
+    {% endif %}
+
+    {% set icon %}
+    <img width="18" height="18" style="padding-top:6px;padding-bottom:4px;" alt="SensioLabs connect" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAP9JREFUeNqslMERgyAQRZ9MCjAdYAcpIQcL0DqSixVkUoEX7ylBS7EDKcEOkss6wzhEQGCGERZ13f/fWtR1TYbRAD2gZW+ADpgumV4+7mJaYq3KkKCX6wy0MuftLLWC0pLlDUzW2QjoHBUcjtQKVjFUAy8rvq1NDpM7kePmMLvLIdEkxhorZiQ2qQgUF+Arc5GYnaSy9tVmuIrgXDs4b3wPq1TOYyl6AMOfe52ci2TBFQwZTH+G9EFhrZcjznfmnmq0Q85jTL6f4Tw0QQN8drK4OK+Aq815SIIYzo38f4KHSuU8pA+0h/My9qtjO3lNrcB4OE+WKInzEImSOPeN3wDknEhKNIf6xwAAAABJRU5ErkJggg==" />
+    <span class="sf-toolbar-status">{{ collector.calls|length }}</span>
+    {% endset %}
+
+    {% set text %}
+    <div class="sf-toolbar-info-piece">
+        <b>Requests</b>
+        <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.calls|length - collector.countErrors }}</span>
+        {% if collector.countErrors > 0 %}
+            + <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.countErrors }}</span>
+        {% endif %}
+    </div>
+    <div class="sf-toolbar-info-piece">
+        <b>Requests time</b>
+        {% if collector.totalTime > 1.0 %}
+            <span>{{ '%0.2f'|format(collector.totalTime) }} s</span>
+        {% else %}
+            <span>{{ '%0.0f'|format(collector.totalTime * 1000) }} ms</span>
+        {% endif %}
+    </div>
+    {% endset %}
+
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': 'connect-sdk' } %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon"><img alt="SensioLabsConnect" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAP9JREFUeNqslMERgyAQRZ9MCjAdYAcpIQcL0DqSixVkUoEX7ylBS7EDKcEOkss6wzhEQGCGERZ13f/fWtR1TYbRAD2gZW+ADpgumV4+7mJaYq3KkKCX6wy0MuftLLWC0pLlDUzW2QjoHBUcjtQKVjFUAy8rvq1NDpM7kePmMLvLIdEkxhorZiQ2qQgUF+Arc5GYnaSy9tVmuIrgXDs4b3wPq1TOYyl6AMOfe52ci2TBFQwZTH+G9EFhrZcjznfmnmq0Q85jTL6f4Tw0QQN8drK4OK+Aq815SIIYzo38f4KHSuU8pA+0h/My9qtjO3lNrcB4OE+WKInzEImSOPeN3wDknEhKNIf6xwAAAABJRU5ErkJggg=="></span>
+        <strong>Connect</strong>
+        <span class="count">
+            {% if collector.calls is not empty %}
+                <span>{{ collector.calls|length }}</span>
+                {% if collector.totalTime > 1.0 %}
+                <span>{{ '%0.2f'|format(collector.totalTime) }} s</span>
+                {% else %}
+                <span>{{ '%0.0f'|format(collector.totalTime * 1000) }} ms</span>
+            {% endif %}
+            {% endif %}
+        </span>
+    </span>
+{% endblock %}
+
+{% block head %}
+    {{ parent() }}
+    <style type="text/css">
+    .icon:before {
+        font-family: FontAwesome;
+        font-weight: normal;
+        font-style: normal;
+        display: inline-block;
+        text-decoration: inherit;
+    }
+
+    div.connect-sdk-profiler div.request {
+        margin-bottom: 10px;
+    }
+
+    div.connect-sdk-profiler div.request div.status {
+        float: left;
+        width: 24px;
+        height: 18px;
+        margin-top: 10px;
+        font-size: 16px;
+    }
+
+    div.connect-sdk-profiler div.request div.status.success:before {
+        color: #d1d1d1;
+        content: "\f00c";
+    }
+
+    div.connect-sdk-profiler div.request div.status.error:before {
+        color: #A41E22;
+        content: "\f071";
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary {
+        font-family: sans-serif;
+        display: block;
+        float: none;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        border: 1px solid;
+        cursor: pointer;
+    }
+
+    div.connect-sdk-profiler div.request.post div.connect-profiler-summary {
+        background-color: #E7F6EC;
+        border-color: #C3E8D1;
+        color: #10A54A;
+    }
+
+    div.connect-sdk-profiler div.request.get div.connect-profiler-summary {
+        background-color: #E7F0F7;
+        border-color: #C3D9EC;
+        color: #0F6AB4;
+    }
+
+    div.connect-sdk-profiler div.request.put div.connect-profiler-summary {
+        background-color: #F9F2E9;
+        border-color: #F0E0CA;
+        color: #C5862B;
+    }
+
+    div.connect-sdk-profiler div.request.delete div.connect-profiler-summary {
+        background-color: #F5E8E8;
+        border-color: #E8C6C7;
+        color: #A41E22;
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary h3 {
+        float: left;
+        font-weight: normal;
+        line-height: 1.1em;
+        font-size: 14px;
+        margin: 0;
+        padding: 0;
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary div.code {
+        display: block;
+        float: right;
+        margin: 6px 10px 0 0;
+        font-size: small;
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary h3 > span.method {
+        text-transform: uppercase;
+        text-decoration: none;
+        color: white;
+        display: inline-block;
+        width: 50px;
+        font-size: 0.9em;
+        text-align: center;
+        margin: 0;
+        padding: 7px 0 4px 0;
+        -moz-border-radius: 2px;
+        -webkit-border-radius: 2px;
+        -o-border-radius: 2px;
+        -ms-border-radius: 2px;
+        -khtml-border-radius: 2px;
+        border-radius: 2px;
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary h3 > span.time {
+        text-decoration: none;
+        color: #999;
+        display: inline-block;
+        width: 95px;
+        font-size: 0.9em;
+        text-align: left;
+        margin: 0;
+        padding: 7px 0 4px 0;
+    }
+
+    div.connect-sdk-profiler div.request.post div.connect-profiler-summary h3 > span.method {
+        background-color: #10a54a;
+    }
+
+    div.connect-sdk-profiler div.request.get div.connect-profiler-summary h3 > span.method {
+        background-color: #0F6AB4;
+    }
+
+    div.connect-sdk-profiler div.request.put div.connect-profiler-summary h3 > span.method {
+        background-color: #C5862B;
+    }
+
+    div.connect-sdk-profiler div.request.delete div.connect-profiler-summary h3 > span.method {
+        background-color: #0F6AB4;
+    }
+
+    div.connect-sdk-profiler div.request div.connect-profiler-summary h3 > span.path {
+        margin: 0;
+        padding: 10px 0 0 0;
+        color: black;
+    }
+
+    div.connect-sdk-profiler .details {
+        display: none;
+        margin-top: 20px;
+    }
+
+    div.connect-sdk-profiler div.request div.details {
+        padding: 0px 0px;
+        color: #313131;
+    }
+
+    div.connect-sdk-profiler div.request div.details .nav {
+        margin-bottom: 5px;
+    }
+
+    div.connect-sdk-profiler div.request div.details .nav li > a {
+        margin: 0;
+        color: #313131;
+        font-size: 1.2em;
+    }
+
+    div.connect-sdk-profiler div.request div.details .nav li.active > a {
+        font-weight: bold;
+    }
+
+    div.connect-sdk-profiler div.request div.details div.tab-content {
+        padding: 10px 20px;
+        border-left: 1px dashed #ddd;
+        border-right: 1px dashed #ddd;
+    }
+
+    div.request h5 {
+        text-align: left;
+        font-size: 1.1em;
+        text-transform: lowercase;
+        font-variant: small-caps;
+        font-weight: bold;
+    }
+
+    div.connect-sdk-profiler div.request pre, div.connect-sdk-profiler div.request code {
+        color: #333;
+        font-size: 13px;
+        font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+    }
+
+    div.connect-sdk-profiler div.request pre {
+        padding: 9.5px;
+        margin: 0 0px 10px 20px;
+        font-size: 11px;
+        background-color: whiteSmoke;
+        white-space: pre;
+        white-space: pre-wrap;
+        border: 1px solid #CCC;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        border-radius: 4px;
+        word-break: break-all;
+        word-wrap: break-word;
+    }
+
+    div.connect-sdk-profiler div.request pre.prettyprint {
+        margin-bottom: 20px;
+    }
+
+    /* Bootstrap progress bar */
+    .progress {
+        height: 20px;
+        overflow: hidden;
+        background-color: #F7F7F7;
+        background-image: -moz-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(whiteSmoke), to(#F9F9F9));
+        background-image: -webkit-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: -o-linear-gradient(top, whiteSmoke, #F9F9F9);
+        background-image: linear-gradient(to bottom, whiteSmoke, #F9F9F9);
+        background-repeat: repeat-x;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        border-radius: 4px;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#fff9f9f9', GradientType=0);
+        -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+    }
+
+    .progress .bar {
+        float: left;
+        width: 0;
+        height: 100%;
+        font-size: 14px;
+        font-weight: light;
+        color: white;
+        text-align: center;
+        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+        background-color: #0E90D2;
+        background-image: -moz-linear-gradient(top, #149BDF, #0480BE);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#149BDF), to(#0480BE));
+        background-image: -webkit-linear-gradient(top, #149BDF, #0480BE);
+        background-image: -o-linear-gradient(top, #149BDF, #0480BE);
+        background-image: linear-gradient(to bottom, #149BDF, #0480BE);
+        background-repeat: repeat-x;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff149bdf', endColorstr='#ff0480be', GradientType=0);
+        -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        -moz-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        -webkit-box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        -webkit-transition: width 0.6s ease;
+        -moz-transition: width 0.6s ease;
+        -o-transition: width 0.6s ease;
+        transition: width 0.6s ease;
+    }
+
+    .progress-striped .bar {
+        background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
+        background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        -webkit-background-size: 40px 40px;
+        -moz-background-size: 40px 40px;
+        -o-background-size: 40px 40px;
+        background-size: 40px 40px;
+    }
+
+    .progress .bar + .bar {
+        -webkit-box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.15), inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        -moz-box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.15), inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.15), inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    }
+
+    .progress-warning .bar, .progress .bar-warning {
+        background-color: #FAA732;
+        background-image: -moz-linear-gradient(top, #FBB450, #F89406);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#FBB450), to(#F89406));
+        background-image: -webkit-linear-gradient(top, #FBB450, #F89406);
+        background-image: -o-linear-gradient(top, #FBB450, #F89406);
+        background-image: linear-gradient(to bottom, #FBB450, #F89406);
+        background-repeat: repeat-x;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450', endColorstr='#fff89406', GradientType=0);
+    }
+
+    .progress-warning.progress-striped .bar, .progress-striped .bar-warning {
+        background-color: #FBB450;
+        background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
+        background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    }
+
+    .progress-success .bar, .progress .bar-success {
+        background-color: #5EB95E;
+        background-image: -moz-linear-gradient(top, #62C462, #57A957);
+        background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#62C462), to(#57A957));
+        background-image: -webkit-linear-gradient(top, #62C462, #57A957);
+        background-image: -o-linear-gradient(top, #62C462, #57A957);
+        background-image: linear-gradient(to bottom, #62C462, #57A957);
+        background-repeat: repeat-x;
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462', endColorstr='#ff57a957', GradientType=0);
+    }
+
+    .progress-success.progress-striped .bar, .progress-striped .bar-success {
+        background-color: #62C462;
+        background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
+        background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    }
+
+    /* Bootstrap nav */
+    .nav {
+        margin-bottom: 20px;
+        margin-left: 0;
+        list-style: none;
+    }
+
+    .nav > li > a {
+        display: block;
+    }
+
+    .nav > li > a:hover {
+        text-decoration: none;
+        background-color: #eeeeee;
+    }
+
+    .nav-tabs {
+        *zoom: 1;
+    }
+
+    .nav-tabs:before,
+    .nav-tabs:after {
+        display: table;
+        line-height: 0;
+        content: "";
+    }
+
+    .nav-tabs:after {
+        clear: both;
+    }
+
+    .nav-tabs > li {
+        float: left;
+    }
+
+    .nav-tabs > li > a {
+        text-decoration: none;
+        padding-right: 12px;
+        padding-left: 12px;
+        margin-right: 2px;
+        line-height: 14px;
+    }
+
+    .nav-tabs {
+        border-bottom: 1px solid #ddd;
+    }
+
+    .nav-tabs > li {
+        margin-bottom: -1px;
+        padding-bottom: 0;
+    }
+
+    .nav-tabs > li > a {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        line-height: 20px;
+        border: 1px solid transparent;
+        -webkit-border-radius: 4px 4px 0 0;
+        -moz-border-radius: 4px 4px 0 0;
+        border-radius: 4px 4px 0 0;
+    }
+
+    .nav-tabs > li > a:hover {
+        border-color: #eeeeee #eeeeee #dddddd;
+    }
+
+    .nav-tabs > .active > a,
+    .nav-tabs > .active > a:hover {
+        color: #555555;
+        cursor: default;
+        background-color: #ffffff;
+        border: 1px solid #ddd;
+        border-bottom-color: transparent;
+    }
+
+    .tab-content {
+        overflow: auto;
+    }
+
+    .tab-content > .tab-pane,
+    .pill-content > .pill-pane {
+        display: none;
+    }
+
+    .tab-content > .active,
+    .pill-content > .active {
+        display: block;
+    }
+
+    .nav > .disabled > a {
+        color: #999999;
+    }
+
+    .nav > .disabled > a:hover {
+        text-decoration: none;
+        cursor: default;
+        background-color: transparent;
+    }
+
+    .prettyprint ol.linenums > li {
+        list-style-type: decimal;
+        padding: 2px 0;
+    }
+
+    </style>
+{% endblock %}
+
+{% block panel %}
+    <h2>{{ (collector.name|capitalize)|default('HTTP calls') }}</h2>
+
+    {% include '@ConnectSDK/Profiler/calls.html.twig' with {'calls': collector.calls } %}
+{% endblock %}

--- a/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/call.html.twig
+++ b/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/call.html.twig
@@ -1,0 +1,44 @@
+<div id="call_{{ index }}" class="request {{ call.request.method|lower }}">
+    <div class="status icon {% if call.error %}error{% else %}success{% endif %}"></div>
+
+    <div class="connect-profiler-summary">
+        <h3>
+            <span class="method">{{ call.request.method }}</span>
+            <span class="time">&nbsp{{ _self.formatDuration(call.time.total ?: 0) }}</span
+            <span class="path">&nbsp{{ call.request.path }}</span>
+        </h3>
+        <div class="code">
+            <abbr title="{{ call.response.reasonPhrase }}">{{ call.response.statusCode }}</abbr>
+        </div>
+    </div>
+
+    <div class="details">
+        <ul class="nav nav-tabs">
+            <li class="active">
+                <a href="#request_{{ index }}" data-toggle="tab">Request</a>
+            </li>
+            <li>
+                <a href="#response_{{ index }}" data-toggle="tab">Response</a>
+            </li>
+        </ul>
+
+        <div class="tab-content">
+            {% include '@ConnectSDK/Profiler/request.html.twig' with {'index':index, 'request': call.request, 'requestContent': call.requestContent, 'time': call.time} %}
+            {% include '@ConnectSDK/Profiler/response.html.twig' with {'index':index, 'response':call.response, 'responseContent': call.responseContent, 'time': call.time} %}
+        </div>
+
+        <div class="progress-striped" style="text-align:center;background-color:#ddd;margin:5px 0 30px 0;padding: 0;font-variant:small-caps;">
+            <div class="bar">
+                <a  style="display:block;text-decoration:none;" href="#call_{{ index }}" title="top">back to top</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% macro formatDuration(duration) %}
+    {% if duration > 1 %}
+        {{ duration | round(2) }} s
+    {% else %}
+        {{ (duration * 1000) | round }} ms
+    {% endif %}
+{% endmacro %}

--- a/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/calls.html.twig
+++ b/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/calls.html.twig
@@ -1,0 +1,41 @@
+<div class="connect-sdk-profiler">
+    <h2>Requests</h2>
+    {% for index,call in calls %}
+        {% include '@ConnectSDK/Profiler/call.html.twig' with { 'call': call } %}
+    {% endfor %}
+</div>
+<script src="//cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.js" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.css">
+<script>
+    (function() {
+        var elems = document.getElementsByClassName('connect-profiler-summary');
+        for (var i= 0; i<elems.length; i += 1) {
+            elems[i].onclick = function() {
+                this.parentNode.getElementsByClassName('details')[0].style.display = 'block';
+            };
+        }
+        window.prettyPrint && prettyPrint()
+
+        var navs = document.getElementsByClassName('nav-tabs');
+
+        for (i = 0; i < navs.length; i += 1) {
+            var tabs = navs[i].parentNode.getElementsByClassName('tab-pane'),
+                lis = navs[i].getElementsByTagName('li');
+
+            for (var j = 0; j < lis.length; j += 1) {
+                lis[j].onclick = function (event) {
+                    event.preventDefault();
+                    for (var k = 0; k<tabs.length; k +=1) {
+                        tabs[k].style.display = 'none';
+                    }
+                    document.getElementById(this.getElementsByTagName('a')[0].getAttribute('href').substr(1)).style.display = 'block';
+
+                    for (var k = 0; k < lis.length; k += 1) {
+                        lis[k].className = lis[k].className.replace('active', '');
+                    }
+                    this.className += 'active';
+                };
+            }
+        }
+    }());
+</script>

--- a/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/request.html.twig
+++ b/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/request.html.twig
@@ -1,0 +1,132 @@
+{% macro display_array_recursive(array, separator = ', ', opening_char = '[', closing_char = ']') -%}
+    {{ opening_char }}
+    {%- for key, value in array -%}
+        {%- if value is iterable -%}
+            {{ key }} => {{ _self.display_array_recursive(value, separator, opening_char, closing_char) }}
+        {%- else -%}
+            {{ key }} => {{ value }}
+            {%- if not loop.last %}{{ separator }}{% endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{ closing_char }}
+{%- endmacro %}
+
+<div id="request_{{ index }}" class="tab-pane active">
+    {% if time.total > 0 %}
+        {% set connection_percent = (100 * time.connection) / time.total %}
+        {% set transfert_percent = (100 * (time.total - time.connection)) / time.total %}
+    {% else %}
+        {% set connection_percent = 0 %}
+        {% set transfert_percent = 100 %}
+    {% endif %}
+
+    <h5>Duration</h5>
+    <table>
+        <tbody>
+        <tr>
+            <th>Total</th>
+            <td>{{ (time.total * 1000)|number_format(0, '', '') }} <small>ms</small></td>
+        </tr>
+        <tr>
+            <th>Connection</th>
+            <td>{{ (time.connection * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ connection_percent|number_format(0, '', '') }}%</td>
+        </tr>
+        <tr>
+            <th>Transfert</th>
+            <td>{{ ((time.total - time.connection) * 1000)|number_format(0, '', '') }} <small>ms</small> - {{ transfert_percent|number_format(0, '', '') }}%</td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <div class="progress progress-striped">
+                    <div class="bar bar-warning" style="width: {{ connection_percent|number_format(0) }}%;">{{ connection_percent|number_format(0) }} %</div>
+                    <div class="bar bar-success" style="width: {{ transfert_percent|number_format(0) }}%;">Transfert {{ transfert_percent|number_format(0) }} %</div>
+                </div>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h5>Informations</h5>
+    <table>
+        <tbody>
+        <tr>
+            <th>Method</th>
+            <td>{{ request.method }}</td>
+        </tr>
+        <tr>
+            <th>Protocol</th>
+            <td>{{ request.scheme }}</td>
+        </tr>
+        <tr>
+            <th>Host</th>
+            <td>{{ request.host }}</td>
+        </tr>
+        <tr>
+            <th>Path</th>
+            <td>{{ request.path }}</td>
+        </tr>
+        <tr>
+            <th>Query</th>
+            <td>{{ request.query }}</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h5>Headers</h5>
+    <table>
+        <tbody>
+        {% for header,value in request.headers %}
+            <tr>
+                <th>{{ header }}</th>
+                <td>{{ value|join('<strong>, </strong>') }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+    <h5>Query Parameters</h5>
+    {% if request.query_parameters | length == 0 %}
+        <p><i>No query parameters.</i></p>
+    {% endif %}
+    <table>
+        <tbody>
+        {% for name,parameter in request.query_parameters %}
+            <tr>
+                <th>{{ name }}</th>
+                <td>
+                    {% if parameter is iterable %}
+                        {{ _self.display_array_recursive(parameter) }}
+                    {% else %}
+                        {{ parameter }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+    {% if request.post_parameters %}
+        <h5>Post Parameters</h5>
+        <table>
+            <tbody>
+            {% for name,parameter in request.post_parameters %}
+                <tr>
+                    <th>{{ name }}</th>
+                    <td>
+                        {% if parameter is iterable %}
+                            {{ _self.display_array_recursive(parameter) }}
+                        {% else %}
+                            {{ parameter }}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    {% if requestContent is not empty %}
+        <h5>Content</h5>
+        <pre class="prettyprint linenums lang-xml">{{ responseContent|nl2br }}</pre>
+    {% endif %}
+</div>

--- a/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/response.html.twig
+++ b/src/SensioLabs/Connect/Profiler/Resources/views/Profiler/response.html.twig
@@ -1,0 +1,30 @@
+<div id="response_{{ index }}" class="tab-pane">
+    <h5>Informations</h5>
+    <table>
+        <tbody>
+        <tr>
+            <th>Code</th>
+            <td>{{ response.statusCode }}</td>
+        </tr>
+        <tr>
+            <th>Status</th>
+            <td>{{ response.reasonPhrase }}</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h5>Headers</h5>
+    <table>
+        <tbody>
+        {% for header,value in response.headers %}
+            <tr>
+                <th>{{ header }}</th>
+                <td>{{ value|join('<strong>, </strong>') }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+    <h5>Content</h5>
+    <pre class="prettyprint linenums lang-xml">{{ responseContent|nl2br }}</pre>
+</div>

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -16,6 +16,8 @@ use Guzzle\Plugin\Backoff\BackoffPlugin;
 use Guzzle\Plugin\Cache\CachePlugin;
 
 const USER_AGENT = 'SensioLabsConnect SDK -';
+const CONNECT_TIMEOUT = 5;
+const TRANSFERT_TIMEOUT = 5;
 
 function createClient($endpoint, array $options = array()) {
     $options = array_replace_recursive(array(
@@ -27,8 +29,8 @@ function createClient($endpoint, array $options = array()) {
             'curl_codes' => null,
         ),
         'options' => array(
-            'timeout' => 5, // maximum number of seconds to allow for an entire transfer to take place before timing out
-            'connect_timeout' => 5, // maximum number of seconds to wait while trying to connect
+            'timeout' => TRANSFERT_TIMEOUT, // maximum number of seconds to allow for an entire transfer to take place before timing out
+            'connect_timeout' => CONNECT_TIMEOUT, // maximum number of seconds to wait while trying to connect
         )
     ), $options);
 

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -51,7 +51,6 @@ function createClient($endpoint, array $options = array())
 
     $client->setDefaultOption('timeout', $options['timeout']);
     $client->setDefaultOption('connect_timeout', $options['connect_timeout']);
-    $client->setDefaultOption('exceptions', false);
 
     if (isset($options['proxy'])) {
         $client->setDefaultOption('proxy', $options['proxy']);

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the SensioLabs Connect package.
+ *
+ * (c) SensioLabs <contact@sensiolabs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\Connect;
+
+use Guzzle\Http\Client as Guzzle;
+use Guzzle\Plugin\Backoff\BackoffPlugin;
+use Guzzle\Plugin\Cache\CachePlugin;
+
+function createClient($endpoint, array $options = array()) {
+    $options = array_replace_recursive(array(
+        'plugins' => array(),
+        'cache_options' => array(),
+        'backoff_options' => array(
+            'max_retries' => 3,
+            'http_codes' => array(500, 503),
+            'curl_codes' => null,
+        ),
+    ), $options);
+
+    if (false !== $options['backoff_options']) {
+        $options['plugins'][] = BackoffPlugin::getExponentialBackoff($options['backoff_options']['max_retries'], $options['backoff_options']['http_codes'], $options['backoff_options']['curl_codes']);
+    }
+
+    if (false !== $options['cache_options']) {
+        $options['plugins'][] = new CachePlugin($options['cache_options']);
+    }
+
+    $client = new Guzzle($endpoint);
+
+    foreach ($options['plugins'] as $plugin) {
+        $client->addSubscriber($plugin);
+    }
+
+    return $client;
+}
+ 

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -19,7 +19,8 @@ const USER_AGENT = 'SensioLabsConnect SDK -';
 const CONNECT_TIMEOUT = 5;
 const TRANSFERT_TIMEOUT = 5;
 
-function createClient($endpoint, array $options = array()) {
+function createClient($endpoint, array $options = array())
+{
     $options = array_replace_recursive(array(
         'plugins' => array(),
         'cache_options' => array(),
@@ -31,7 +32,7 @@ function createClient($endpoint, array $options = array()) {
         'options' => array(
             'timeout' => TRANSFERT_TIMEOUT, // maximum number of seconds to allow for an entire transfer to take place before timing out
             'connect_timeout' => CONNECT_TIMEOUT, // maximum number of seconds to wait while trying to connect
-        )
+        ),
     ), $options);
 
     if (false !== $options['backoff_options']) {
@@ -60,4 +61,3 @@ function createClient($endpoint, array $options = array()) {
 
     return $client;
 }
- 

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -15,6 +15,8 @@ use Guzzle\Http\Client as Guzzle;
 use Guzzle\Plugin\Backoff\BackoffPlugin;
 use Guzzle\Plugin\Cache\CachePlugin;
 
+const USER_AGENT = 'SensioLabsConnect SDK -';
+
 function createClient($endpoint, array $options = array()) {
     $options = array_replace_recursive(array(
         'plugins' => array(),
@@ -51,6 +53,8 @@ function createClient($endpoint, array $options = array()) {
     if (isset($options['proxy'])) {
         $client->setDefaultOption('proxy', $options['proxy']);
     }
+
+    $client->setUserAgent(USER_AGENT, true);
 
     return $client;
 }

--- a/src/SensioLabs/Connect/functions.php
+++ b/src/SensioLabs/Connect/functions.php
@@ -24,6 +24,10 @@ function createClient($endpoint, array $options = array()) {
             'http_codes' => array(500, 503),
             'curl_codes' => null,
         ),
+        'options' => array(
+            'timeout' => 5, // maximum number of seconds to allow for an entire transfer to take place before timing out
+            'connect_timeout' => 5, // maximum number of seconds to wait while trying to connect
+        )
     ), $options);
 
     if (false !== $options['backoff_options']) {
@@ -38,6 +42,14 @@ function createClient($endpoint, array $options = array()) {
 
     foreach ($options['plugins'] as $plugin) {
         $client->addSubscriber($plugin);
+    }
+
+    $client->setDefaultOption('timeout', $options['timeout']);
+    $client->setDefaultOption('connect_timeout', $options['connect_timeout']);
+    $client->setDefaultOption('exceptions', false);
+
+    if (isset($options['proxy'])) {
+        $client->setDefaultOption('proxy', $options['proxy']);
     }
 
     return $client;


### PR DESCRIPTION
The PR is ready, anyway I tag it as wip because:

 - We have bundle to prepare/migrate
 - We need to address few things I'm not really sure (Api::submit method is deprecated in favor of Api::get and Api::post. Does other method are in use ? patch ? head ? So we probably should rename it to createRequest and rovide a BC. I definitely don't like the `submit` word :) )
 - Should we introduce the user agent in this library ? 

 - [x] Use Guzzle
 - [x] Rename `browser` to `client`
 - [x] Provide compatibility with PSRLoggerInterface (`err` is not a valid method)
 - [x] Add backoff plugin + options
 - [x] Reduce connection timeout
 - [x] Add proxy options
 - [x] Add UserAgent
 - [x] Update doc, mention BC break
 - [x] Move data collector from SensioLabsConnectBundle to this repo as it would be usable in silex provider